### PR TITLE
Removed override notation for deprecated method (createJSModules) of …

### DIFF
--- a/android/src/main/java/com/bitgo/randombytes/RandomBytesPackage.java
+++ b/android/src/main/java/com/bitgo/randombytes/RandomBytesPackage.java
@@ -27,7 +27,7 @@ public class RandomBytesPackage implements ReactPackage {
     return Collections.emptyList();
   }
 
-  @Override
+  // Deprecated from RN 0.47.0
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
…RN 0.47.0

https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8