### PR TITLE
Fix ios compile error on RN 0.48+

### DIFF
--- a/RNRandomBytes.h
+++ b/RNRandomBytes.h
@@ -7,7 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <React/RCTBridgeModule.h>
+
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
+#endif
 #import <React/RCTBridge.h>
 
 @interface RNRandomBytes : NSObject<RCTBridgeModule>


### PR DESCRIPTION
This PR fixes a compile error in iOS when using RN v0.48 or higher. Issue referenced here:

https://github.com/yonahforst/react-native-permissions/issues/137