### PR TITLE
Prevent hard wrap on Android

### DIFF
--- a/android/src/main/java/com/bitgo/randombytes/RandomBytesModule.java
+++ b/android/src/main/java/com/bitgo/randombytes/RandomBytesModule.java
@@ -40,6 +40,6 @@ class RandomBytesModule extends ReactContextBaseJavaModule {
     SecureRandom sr = new SecureRandom();
     byte[] output = new byte[size];
     sr.nextBytes(output);
-    return Base64.encodeToString(output, Base64.DEFAULT);
+    return Base64.encodeToString(output, Base64.NO_WRAP);
   }
 }


### PR DESCRIPTION
When requesting random bytes over a certain size, the `Base64.DEFAULT` option on android inserts hard wraps (extra `\n` characters) into the string. This is really annoying to deal with from the JS side as we'd have to strip these characters before the string can be decoded into a byte array.

See https://stackoverflow.com/a/25011746/350761

This patch makes the Android behavior align with iOS (no hard wraps) by passing the [NO_WRAP](https://developer.android.com/reference/android/util/Base64.html#NO_WRAP) flag.