### PR TITLE
Support latest react native version (Android)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.2')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Right now the latest version of react-native (v0.56) requires buildTools 26 and this library breaks the build cause it's using v23

![screen shot 2018-07-25 at 5 59 55 pm](https://user-images.githubusercontent.com/1247834/43230060-ef904766-9034-11e8-9a2d-6ac21b1909f9.png)

This PR fixes the issue.

