### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/react-native-randombytes.podspec
+++ b/react-native-randombytes.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, "7.0"
   s.source         = { :git => "#{package_json["repository"]["url"]}" }
   s.source_files   = '*.{h,m}'
-  s.dependency 'React'
+  s.dependency 'React-Core'
 
 end


### PR DESCRIPTION
Summary
Xcode 12 won't build if a module depends on React instead of React-Core. 

Reference: facebook/react-native#29633 (comment)