### PR TITLE
fix: Check Null for RNRandomBytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,11 +12,13 @@ function toBuffer (nativeStr) {
 }
 
 function init () {
-  if (RNRandomBytes.seed) {
-    let seedBuffer = toBuffer(RNRandomBytes.seed)
-    addEntropy(seedBuffer)
-  } else {
-    seedSJCL()
+  if (RNRandomBytes) {
+    if (RNRandomBytes.seed) {
+      let seedBuffer = toBuffer(RNRandomBytes.seed)
+      addEntropy(seedBuffer)
+    } else {
+      seedSJCL()
+    }
   }
 }
 


### PR DESCRIPTION
### lssues: #40 
Expo projects that use the `react-native-crypto` library have problems with `react-native-randombytes`.

_Uncaught Error:_
> null is not an object (evaluating 'RNRandomBytes.seed')
![simulator_screenshot_AF257038-13CE-4691-A4DF-BDD3D8541EAC](https://user-images.githubusercontent.com/81867914/171803211-894a8ce5-cb30-4e8d-b242-32edf35ec33c.png)

means that the RNrandomBytes value is uninitialized. So make sure this value is initialized properly first.
###  Check Null for RNRandomBytes:
I used if to check if RandomBytes is initialized. This solves the problem with Expo react-native mentioned in issue #40 
### Testing:
Have been tested on Android simulator, iOS simulator, and Android devices, iOS devices.
_react-native: 0.64
Expo: 44
react-native-crypto: 2.2